### PR TITLE
Fix code example typo

### DIFF
--- a/nomi-significativi.md
+++ b/nomi-significativi.md
@@ -19,7 +19,7 @@ $a = true;
 Esempio di buon nome:
 
 ```text
-daysSinceCreation = 12;
+$daysSinceCreation = 12;
 $flaggedCells = [];
 $isFlagged = true;
 ```


### PR DESCRIPTION
Fixes a small typo in a code example about variable naming